### PR TITLE
Maintainence

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,12 +7,16 @@
 		"args": { "VARIANT": "ubuntu-22.04" }
 	},
 
-	"extensions": [
-		"Dart-Code.flutter",
-		"alexisvt.flutter-snippets",
-		"pinage404.bash-extension-pack",
-		"shakram02.bash-beautify"
-	],
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"Dart-Code.flutter",
+				"alexisvt.flutter-snippets",
+				"shakram02.bash-beautify",
+				"pinage404.bash-extension-pack"
+			]
+		}
+	},
 
     
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 	"extensions": [
 		"Dart-Code.flutter",
 		"alexisvt.flutter-snippets",
-		"lizebang.bash-extension-pack",
+		"pinage404.bash-extension-pack",
 		"shakram02.bash-beautify"
 	],
 

--- a/Image/Dockerfile
+++ b/Image/Dockerfile
@@ -33,7 +33,7 @@ RUN ls -la ${HOME}/ && ls -la ${CMDLINE_HOME} && echo ${CMDLINE_HOME} && sudo ch
 RUN sudo chmod +r+w+x -Rv ${HOME}/.local
 
 # Install cmdlinetools and sdk
-RUN sudo apt-get install openjdk-11-jdk --no-install-recommends -y
+RUN sudo apt-get install openjdk-21-jdk --no-install-recommends -y
 RUN yes | sdkmanager --install "build-tools;29.0.0" "platforms;android-29" "platform-tools" "cmdline-tools;latest"
 
 # setup flutter


### PR DESCRIPTION
- replaced bash extention pack with a working id.
- bump openjdk version to 21 to satisfy Android sdk requirements.
- satisfy the `devcontainer.json` schema by declaring required extentions in `customizations` object